### PR TITLE
(WIP) Switch to plone.testing to avoid test isolation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   - downloads
 python:
   - 2.7
+  - 3.6
 matrix:
   fast_finish: true
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ CHANGES
 - Remove deprecatared __of__ for BrowserViews
   [MrTango]
 
+- Switch test setup to use plone.testing
+
+
 1.1 (2012-08-30)
 ----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ CHANGES
 - Remove deprecatared __of__ for BrowserViews
   [MrTango]
 
-- Switch test setup to use plone.testing
+- Switch test setup to use plone.testing.
 
 
 1.1 (2012-08-30)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     ],
     extras_require={
         'test': [
+            'plone.testing',
             'zope.publisher',
             'zope.site',
             'zope.testing',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     ],
     extras_require={
         'test': [
-            'plone.testing',
+            'plone.testing>=7',
             'zope.publisher',
             'zope.site',
             'zope.testing',

--- a/src/five/customerize/browser.txt
+++ b/src/five/customerize/browser.txt
@@ -1,31 +1,18 @@
 Viewing TTWViewTemplates through-the-web
 ========================================
 
-Set Up
-------
-
-Make this test available as a module so that stuff defined in here can
-be pickled properly:
-
-    >>> from zope.testing import module
-    >>> module.setUp(test, name='five.customerize.browsertest')
-
-
 Making a site
 -------------
 
+    >>> app = layer['app']
     >>> uf = app.acl_users
     >>> _ignore = uf._doAddUser('manager', 'r00t', ['Manager'], [])
+    >>> import transaction; transaction.commit()
 
 Create the test browser we'll be using:
 
-    # BBB Zope 2.12
-    >>> try:
-    ...     from Testing.testbrowser import Browser
-    ... except ImportError:
-    ...     from Products.Five.testbrowser import Browser
-
-    >>> browser = Browser()
+    >>> from plone.testing.zope import Browser
+    >>> browser = Browser(app)
     >>> browser.addHeader('Authorization', 'Basic manager:r00t')
 
 Make a folder to use as a local site for component registration:
@@ -52,7 +39,6 @@ XXX: We should be able to do this TTW
     >>> sm = app.folder.getSiteManager()
     >>> sm.registerAdapter(template, (IObjectManager, IDefaultBrowserLayer),
     ...                    Interface, name='myttwtemplate.html')
-    >>> import transaction
     >>> transaction.commit()
 
 Let's see if we can view it:
@@ -78,16 +64,6 @@ Now we edit our view template TTW:
 
 Make and register a view that we can customize with a TTWViewTemplate:
 
-    >>> from Products.Five.browser import BrowserView
-    >>> class TestView(BrowserView):
-    ...     """A view class"""
-    ...     __name__ = 'mystaticview.html'
-    ...     def foo_method(self):
-    ...         return 'baz'
-    ...
-    ...     def __call__(self):
-    ...         return 'Original View'
-
     >>> from zope.component import provideAdapter
     >>> provideAdapter(TestView, (IObjectManager, IDefaultBrowserLayer),
     ...                    Interface, name='mystaticview.html')
@@ -104,6 +80,7 @@ it locally to override the static view:
     >>> sm = app.folder.getSiteManager()
     >>> sm.registerAdapter(template, (IObjectManager, IDefaultBrowserLayer),
     ...                    Interface, name='mystaticview.html')
+    >>> transaction.commit()
 
 Now we browse the view to ensure that is has changed:
 
@@ -123,10 +100,3 @@ view methods:
     >>> print(browser.contents)
     Customized
     baz
-
-Clean up:
----------
-
-    >>> module.tearDown(test, name='five.customerize.browsertest')
-    >>> from zope.testing.cleanup import cleanUp
-    >>> cleanUp()

--- a/src/five/customerize/customerize.txt
+++ b/src/five/customerize/customerize.txt
@@ -21,13 +21,7 @@ global view component.  The steps in this story are:
 Setup
 -----
 
-Make this test a usable module
-
-  >>> from zope.testing import module
-  >>> module.setUp(test, name='five.customerize.testcustomerize')
-
-XXX: we are using root as the app name
-  >>> root = self.folder
+  >>> app = layer['app']
 
 
 1. Turning an ObjectManager into a site
@@ -41,8 +35,8 @@ Let's create a folder that we'll turn into a Zope3-style site:
 We need to add it to the root so that objects contained in it have a
 proper acquisition chain all the way to the top:
 
-  >>> id = root._setObject('site', site)
-  >>> site = root.site
+  >>> id = app._setObject('site', site)
+  >>> site = app.site
 
 Now we make this a real site by using a view that a) sets
 ``IObjectManagerSite``, b) sets a traversal hook and c) gives the site
@@ -50,7 +44,7 @@ a component registration object (formerly known as site manager):
 
   >>> import zope.component
   >>> from zope.publisher.browser import TestRequest
-  >>> request = root.REQUEST
+  >>> request = app.REQUEST
   >>> view = zope.component.getMultiAdapter((site, request),
   ...                                       name=u"components.html")
   >>> view.makeSite()
@@ -101,8 +95,8 @@ the source of its template:
   >>> view = zope.component.getMultiAdapter((item, request),
   ...                                       name=u"customizezpt.html")
   >>> template = view.templateFromViewName(u'customizezpt.html')
-  >>> aq_base(template)
-  <...PageTemplateFile ...>
+  >>> 'PageTemplateFile' in repr(aq_base(template))
+  True
   >>> import os.path
   >>> os.path.basename(template.filename)
   'customize.pt'
@@ -165,7 +159,10 @@ so calling it will fail unless logged in:
 
 Now look it up as manager and compare its output:
 
-  >>> self.setRoles(['Manager',])
+  >>> from plone.testing.zope import login
+  >>> app['acl_users'].userFolderAddUser('admin', 'secret', ['Manager'], [])
+  <User 'admin'>
+  >>> login(app['acl_users'], 'admin')
   >>> view = zope.component.getMultiAdapter((item, request),
   ...                                       name=u"customizezpt.html")
   >>> print(view()) # doctest: +ELLIPSIS
@@ -183,8 +180,7 @@ Now look it up as manager and compare its output:
 Once in a while we would like to get rid of the customized view.  The
 easiest way to do that is to simply delete the template:
 
-  >>> if True:
-  ...     site._delObject('customize.pt')
+  >>> site._delObject('customize.pt')
 
 Now the view look-up is back to the old way:
 
@@ -218,13 +214,7 @@ available to the customized local view.  We create one of these views
   ...     makeClassForTemplate = None
   ...     from Products.Five.browser.metaconfigure import SimpleViewClass
 
-
-  # BBB Zope 2.12
-  >>> try:
-  ...     from AccessControl.security import getSecurityInfo, protectClass
-  ... except ImportError:
-  ...     from Products.Five.security import getSecurityInfo, protectClass
-
+  >>> from AccessControl.security import getSecurityInfo, protectClass
   >>> from AccessControl.class_init import InitializeClass
   >>> viewclass = None
   >>> if makeClassForTemplate:
@@ -255,12 +245,8 @@ Now we retrieve the view and make sure it does what it should:
 
   >>> view = zope.component.getMultiAdapter((item, request),
   ...                                       name=u"simpleview.html")
-  >>> print(view())
-  <html>
-  ...
-  A simple view template with a class
-  baz
-  ...
+  >>> 'A simple view template with a class' in view()
+  True
 
 And we customize it:
 
@@ -276,13 +262,5 @@ And render it again:
 
   >>> view = zope.component.getMultiAdapter((item, request),
   ...                                       name=u"simpleview.html")
-  >>> print(view())
-  A customized view
-  baz
-
-Clean up:
----------
-
-  >>> module.tearDown(test, name='five.customerize.testcustomerize')
-  >>> from zope.testing.cleanup import cleanUp
-  >>> cleanUp()
+  >>> 'A customized view' in view()
+  True

--- a/src/five/customerize/zpt.txt
+++ b/src/five/customerize/zpt.txt
@@ -4,10 +4,12 @@ TTW Template Tests
 First we create a simple TTWViewTemplate object and then we obtain a
 renderer by calling as if it were a view factory:
 
+    >>> app = layer['app']
+    >>> app.id = 'folder'
     >>> from five.customerize.zpt import TTWViewTemplate
     >>> template = TTWViewTemplate('test_template', '<html></html>')
     >>> template = template.__of__(app)
-    >>> renderer = template(self.folder, None)
+    >>> renderer = template(app, None)
     >>> print(renderer())
     <html></html>
 
@@ -15,14 +17,14 @@ We now add some more complex TAL expressions to our template, and
 ensure that it obtains the passed in request and context for rendering:
 
     >>> template.pt_edit('''\
-    ... <span tal:replace="context/getId"/>
+    ... <span tal:replace="context/id"/>
     ... <span tal:replace="request/foo"/>
     ... <span tal:replace="python:repr(view)"/>''', 'text/html')
 
     >>> from zope.publisher.browser import TestRequest
     >>> request = TestRequest(environ={'foo': 'bar'})
-    >>> renderer = template(self.folder, request)
+    >>> renderer = template(app, request)
     >>> print(renderer())
-    test_folder_1_
+    folder
     bar
     None


### PR DESCRIPTION
Pushing this as a work in progress before I head to bed. The converted tests pass in isolation but I'm still getting an error when run as part of the full Plone tests...some problem while trying to create a local ZCA site manager using five.localsitemanager, related to the stacked component registries from plone.testing:

```
Error in test /Users/davisagli/.buildout/eggs/five.localsitemanager-3.1-py3.6.egg/five/localsitemanager/browser.txt
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 2282, in debug
    runner.run(self._dt_test, clear_globs=False)
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1839, in run
    r = DocTestRunner.run(self, test, compileflags, out, False)
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1476, in run
    return self.__run(test, compileflags, out)
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1382, in __run
    exception)
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1845, in report_unexpected_exception
    raise UnexpectedException(test, example, exc_info)
doctest.UnexpectedException: <DocTest browser.txt from /Users/davisagli/.buildout/eggs/five.localsitemanager-3.1-py3.6.egg/five/localsitemanager/browser.txt:0 (27 examples)>

IndexError: tuple index out of range

> /Users/davisagli/.buildout/eggs/five.localsitemanager-3.1-py3.6.egg/five/localsitemanager/browser.py(40)sitemanagerTrail()
-> sm = sm.__bases__[0]
(Pdb) l
 35     
 36             sm = self.context.getSiteManager()
 37             trail = []
 38             while sm is not None and sm != base:
 39                 trail.append(repr(sm))
 40  ->             sm = sm.__bases__[0]
 41     
 42             if sm == base:
 43                 trail.append('Global Registry')
 44     
 45             trail.reverse()
(Pdb) sm
<BaseGlobalComponents base>
(Pdb) sm.__bases__
()
(Pdb) base
<BaseGlobalComponents test-stack-2>
```
