### PR TITLE
Fix tests to run successfully on Zope >= 5.2.1.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ CHANGES
 
 - Add support for Python 3.5, 3.7, 3.8 and 3.9.
 
+- Fix tests to run successfully on Zope >= 5.2.1.
+
 
 2.0.1 (2020-03-21)
 ------------------

--- a/src/five/customerize/zpt.txt
+++ b/src/five/customerize/zpt.txt
@@ -21,8 +21,14 @@ ensure that it obtains the passed in request and context for rendering:
     ... <span tal:replace="request/foo"/>
     ... <span tal:replace="python:repr(view)"/>''', 'text/html')
 
-    >>> from zope.publisher.browser import TestRequest
-    >>> request = TestRequest(environ={'foo': 'bar'})
+    >>> from ZPublisher.HTTPRequest import HTTPRequest
+    >>> ENV = {
+    ...     'SERVER_NAME': 'localhost',
+    ...     'SERVER_PORT': '8080',
+    ...     'SCRIPT_NAME': '/test_template',
+    ... }
+    >>> request = HTTPRequest(stdin=None, environ=ENV, response=None)
+    >>> request.form = {'foo': 'bar'}
     >>> renderer = template(app, request)
     >>> print(renderer())
     folder

--- a/src/five/customerize/zpt.txt
+++ b/src/five/customerize/zpt.txt
@@ -21,15 +21,10 @@ ensure that it obtains the passed in request and context for rendering:
     ... <span tal:replace="request/foo"/>
     ... <span tal:replace="python:repr(view)"/>''', 'text/html')
 
-    >>> from ZPublisher.HTTPRequest import HTTPRequest
-    >>> ENV = {
-    ...     'SERVER_NAME': 'localhost',
-    ...     'SERVER_PORT': '8080',
-    ...     'SCRIPT_NAME': '/test_template',
-    ... }
-    >>> request = HTTPRequest(stdin=None, environ=ENV, response=None)
-    >>> request.form = {'foo': 'bar'}
-    >>> renderer = template(app, request)
+    >>> from Testing.makerequest import makerequest
+    >>> app = makerequest(app)
+    >>> app.REQUEST.form = {'foo': 'bar'}
+    >>> renderer = template(app, app.REQUEST)
     >>> print(renderer())
     folder
     bar


### PR DESCRIPTION
Fixes #14.

The test failed because `zope.publisher.browser.TestRequest` does not have the necessary security set-up.
I replaced it with `ZPublisher.HTTPRequest.HTTPRequest`.

But now the code does not look very nice and I am not sure if I used that class in the way it was designed. (All the given keys in `ENV` are expected by `HTTPRequest`. Writing directly to the `form` attribute feels wrong.) 
Any guidance would be helpful.