### PR TITLE
Drop Python 2 leftovers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ CHANGES
 
 - Drop support for Python 3.7, 3.8.
 
+- Drop Python 2 leftovers.
+
 3.0.0 (2024-01-19)
 ------------------
 

--- a/src/five/customerize/browser.py
+++ b/src/five/customerize/browser.py
@@ -3,7 +3,6 @@ from os.path import isabs
 from os.path import sep
 from os.path import split
 
-import six
 from Acquisition import aq_inner
 from Products.Five.browser import BrowserView
 from Products.Five.component import findSite
@@ -138,8 +137,6 @@ class CustomizationView(BrowserView):
         # Zope 3's ZPT implementation.
         with open(template.filename, 'rb') as f:
             data = f.read()
-        if six.PY2:
-            return data
         return data.decode('utf-8')
 
     def permissionFromViewName(self, viewname):

--- a/src/five/customerize/tests.py
+++ b/src/five/customerize/tests.py
@@ -35,11 +35,6 @@ FIVE_CUSTOMERIZE_FUNCTIONAL_TESTING = zope.FunctionalTesting(
     bases=(FIVE_CUSTOMERIZE_FIXTURE,), name="five.customerize:FUNCTIONAL")
 
 
-class Py23DocChecker(doctest.OutputChecker):
-    def check_output(self, want, got, optionflags):
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
-
-
 class TestView(BrowserView):
     """A view class"""
     __name__ = 'mystaticview.html'
@@ -60,7 +55,6 @@ def test_suite():
         layered(
             doctest.DocFileSuite(
                 'customerize.txt',
-                checker=Py23DocChecker(),
             ),
             layer=FIVE_CUSTOMERIZE_FUNCTIONAL_TESTING,
         ),

--- a/src/five/customerize/tests.py
+++ b/src/five/customerize/tests.py
@@ -1,5 +1,4 @@
 import doctest
-import re
 import unittest
 
 from plone.testing import Layer
@@ -7,7 +6,6 @@ from plone.testing import layered
 from plone.testing import zca
 from plone.testing import zope
 
-import six
 from Products.Five.browser import BrowserView
 from zope.configuration import xmlconfig
 
@@ -39,12 +37,6 @@ FIVE_CUSTOMERIZE_FUNCTIONAL_TESTING = zope.FunctionalTesting(
 
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
-        if six.PY2:
-            got = re.sub(
-                'Unauthorized',
-                'AccessControl.unauthorized.Unauthorized',
-                got)
-            got = re.sub("u'(.*?)'", "'\\1'", got)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 


### PR DESCRIPTION
Something broke the last run of #25: The dependencies no longer seem to require `six`.
It was not declared here but used for Python 2 compatibility.